### PR TITLE
Fix 'fileutils' require so that it works on case-sensitive filesystems. 

### DIFF
--- a/VimAck/Classes/AppDelegate.rb
+++ b/VimAck/Classes/AppDelegate.rb
@@ -5,7 +5,7 @@
 #  Copyright 2011 Majd Taby. All rights reserved.
 #
 
-require 'FileUtils'
+require 'fileutils'
 
 class AppDelegate
     


### PR DESCRIPTION
On case-insensitive filesystems, require will work with any mixed case argument. On a case-sensitive filesystem, you need to use the actual filename from the Ruby standard library.
