### PR TITLE
Fix shellescape in Waldo.vim (before: 'waldo://'/Users/msch/...') 

### DIFF
--- a/Waldo.vim
+++ b/Waldo.vim
@@ -22,7 +22,7 @@ set cpo&vim
 
 function s:LaunchWaldoViaVim()
   let cwd = getcwd()
-  silent exe  "!open 'waldo://" . shellescape(cwd)
+  silent exe  "!open " . shellescape("waldo://" . cwd)
 endfunction
 
 command! Waldo :call <SID>LaunchWaldoViaVim()


### PR DESCRIPTION
Waldo.vim tried to call

```
waldo://'/Users/msch/...'
```

Fixed this.
